### PR TITLE
docs(claude): add OpenSpec governance for CLAUDE.md (update-doc-claude)

### DIFF
--- a/openspec/changes/update-doc-claude/test_plan.md
+++ b/openspec/changes/update-doc-claude/test_plan.md
@@ -1,0 +1,13 @@
+# Test Plan: update-doc-claude
+
+## Goals
+- Validate that `docs/CLAUDE.md` meets OpenSpec governance requirements.
+- Ensure proposal, tasks, and delta spec exist and are valid.
+
+## Checks
+- [ ] Lint markdown files under this change directory
+- [ ] Run validation: `openspec validate update-doc-claude --strict`
+- [ ] Confirm CI passes for PR
+
+## Exit Criteria
+- All checks above are green and PR is merged.

--- a/openspec/changes/update-doc-claude/todo.md
+++ b/openspec/changes/update-doc-claude/todo.md
@@ -1,0 +1,24 @@
+# TODO: Update Claude Documentation (update-doc-claude)
+
+## Workflow Progress
+- [ ] 0. Create TODOs
+- [ ] 1. Increment Release Version
+- [ ] 2. Proposal
+- [ ] 3. Specification
+- [ ] 4. Task Breakdown
+- [ ] 5. Test Definition
+- [ ] 6. Script & Tooling
+- [ ] 7. Implementation
+- [ ] 8. Test Run & Validation
+- [ ] 9. Documentation Update
+- [ ] 10. Git Operations
+- [ ] 11. Create Pull Request (PR)
+- [ ] 12. Archive Completed Change
+- [ ] 13. Workflow Improvement
+
+## Artifacts Created
+- [x] proposal.md
+- [x] specs/project-documentation/spec.md
+- [x] tasks.md
+- [ ] test_plan.md
+- [ ] retrospective.md


### PR DESCRIPTION
Implements openspec/changes/update-doc-claude.\n\n- Adds Governance (OpenSpec) section to docs/CLAUDE.md\n- Aligns with project-documentation capability\n- Validation: openspec validate update-doc-claude --strict\n\n[OpenSpec]