### PR TITLE
docs(constitution): add OpenSpec governance for docs/CONSTITUTION.md (update-doc-docs-constitution)

### DIFF
--- a/openspec/changes/update-doc-docs-constitution/test_plan.md
+++ b/openspec/changes/update-doc-docs-constitution/test_plan.md
@@ -1,0 +1,13 @@
+# Test Plan: update-doc-docs-constitution
+
+## Goals
+- Validate that `docs/CONSTITUTION.md` governance is documented and compliant with OpenSpec.
+- Ensure the change directory contains proposal, tasks, and delta spec.
+
+## Checks
+- [ ] Lint markdown files under this change directory
+- [ ] Run validation: `openspec validate update-doc-docs-constitution --strict`
+- [ ] Confirm CI passes for PR
+
+## Exit Criteria
+- All checks above are green and PR is merged.

--- a/openspec/changes/update-doc-docs-constitution/todo.md
+++ b/openspec/changes/update-doc-docs-constitution/todo.md
@@ -1,0 +1,24 @@
+# TODO: Update Constitution Documentation (update-doc-docs-constitution)
+
+## Workflow Progress
+- [ ] 0. Create TODOs
+- [ ] 1. Increment Release Version
+- [ ] 2. Proposal
+- [ ] 3. Specification
+- [ ] 4. Task Breakdown
+- [ ] 5. Test Definition
+- [ ] 6. Script & Tooling
+- [ ] 7. Implementation
+- [ ] 8. Test Run & Validation
+- [ ] 9. Documentation Update
+- [ ] 10. Git Operations
+- [ ] 11. Create Pull Request (PR)
+- [ ] 12. Archive Completed Change
+- [ ] 13. Workflow Improvement
+
+## Artifacts Created
+- [x] proposal.md
+- [x] specs/project-documentation/spec.md
+- [x] tasks.md
+- [ ] test_plan.md
+- [ ] retrospective.md


### PR DESCRIPTION
Implements openspec/changes/update-doc-docs-constitution.\n\n- Adds Governance (OpenSpec) section to docs/CONSTITUTION.md\n- Delta set to MODIFIED with validation requirements\n- Validation: openspec validate update-doc-docs-constitution --strict\n\n[OpenSpec]